### PR TITLE
DNS Resolver - catch for all exceptions

### DIFF
--- a/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
+++ b/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
@@ -19,6 +19,7 @@ package org.apache.tuweni.discovery
  */
 
 import io.vertx.core.Vertx
+import io.vertx.core.VertxException
 import io.vertx.core.dns.DnsClient
 import io.vertx.core.dns.DnsClientOptions
 import io.vertx.core.dns.DnsException
@@ -31,6 +32,7 @@ import org.apache.tuweni.crypto.SECP256K1
 import org.apache.tuweni.devp2p.EthereumNodeRecord
 import org.slf4j.LoggerFactory
 import java.io.IOException
+import java.lang.Exception
 
 /**
  * Resolves a set of ENR nodes from a host name.
@@ -157,6 +159,13 @@ class DNSResolver @JvmOverloads constructor(
       return null
     } catch (e: IOException) {
       logger.warn("I/O exception contacting remote DNS server when resolving $domainName", e)
+      return null
+    } catch (e: VertxException) {
+      // timeouts are common
+      logger.warn("Vertx exception contacting remote DNS server when resolving $domainName", e)
+      return null
+    } catch (e: Exception) {
+      logger.warn("Exception contacting remote DNS server when resolving $domainName", e)
       return null
     }
   }


### PR DESCRIPTION
Broaden exception handling to catch any exception - current impl is resulting in this uncaught exception (in besu) and DNS processing halts altogether. Catching this will enable DNS search to continue.

`Uncaught exception in thread “vert.x-eventloop-thread-3”“,”throwable”:” io.vertx.core.VertxException: DNS query timeout for xxx.ethdisco.net ...`



## PR description

## Fixed Issue(s)
Related to this -
https://github.com/hyperledger/besu/issues/1707
