### PR TITLE
fix: update vertx-core to 4.5.24 to patch CVE

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -22,7 +22,7 @@ dependencyManagement {
     dependency('com.google.guava:guava:32.1.2-jre')
     dependency('com.squareup.okhttp3:okhttp:5.0.0-alpha.11')
 
-    dependencySet(group: 'io.vertx', version: '4.5.22') {
+    dependencySet(group: 'io.vertx', version: '4.5.24') { // https://github.com/advisories/GHSA-cphf-4846-3xx9
       entry 'vertx-core'
       entry 'vertx-lang-kotlin-coroutines'
     }


### PR DESCRIPTION
## Summary
- Update `io.vertx:vertx-core` from 4.5.22 to 4.5.24 to fix security vulnerability

## Security Issue
**CVE:** [GHSA-cphf-4846-3xx9](https://github.com/advisories/GHSA-cphf-4846-3xx9)

The Vert.x Web static handler component cache can be manipulated to deny access to static files served by the handler using specifically crafted request URIs.

**Affected versions:** < 4.5.24  
**Patched version:** 4.5.24

## Test Plan
- [x] `./gradlew build` passes all tests
- [x] Dependency tree shows `io.vertx:vertx-core -> 4.5.24`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Security patch via dependency bump.
> 
> - Update `io.vertx` dependency set from `4.5.22` to `4.5.24` in `dependency-versions.gradle`, upgrading `vertx-core` and `vertx-lang-kotlin-coroutines` to address `GHSA-cphf-4846-3xx9`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d3418398e8b31f144936d959e127dacebc79cd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->